### PR TITLE
issue typescript

### DIFF
--- a/packages/ui/src/forms/Button.tsx
+++ b/packages/ui/src/forms/Button.tsx
@@ -13,6 +13,7 @@ import {
   // type ComponentType,
   type PropsWithChildren,
   useId,
+  ComponentType,
 } from 'react';
 import { colorVariants } from '../variants/colors';
 import { sizeVariants } from '../variants/size';
@@ -63,7 +64,7 @@ const ButtonFrame = styled(MotiPressable, {
     variant: 'outlined',
     space: 'xs',
   },
-}) as any;
+});
 
 const ButtonTextFrame = styled(Text, {
   className: ['font-semibold'],
@@ -114,12 +115,11 @@ const ButtonTextFrame = styled(Text, {
   ],
 });
 
-type ButtonRootProps = any;
-// GetProps<typeof ButtonFrame> & {
-//   text?: string;
-//   iconAfter?: ComponentType;
-//   icon?: ComponentType;
-// };
+type ButtonRootProps = GetProps<typeof ButtonFrame> & {
+  text?: string;
+  iconAfter?: ComponentType;
+  icon?: ComponentType;
+};
 
 function ButtonRoot(
   props: Omit<ButtonRootProps, 'text' | 'iconAfter' | 'icon'>


### PR DESCRIPTION
Exported variable 'ButtonFrame' has or is using name 'DecayConfig' from external module "/srv/mergeui/node_modules/.pnpm/react-native-reanimated@3.4.2_6syixf76bqx5r4tgwtwyqyssoi/node_modules/react-native-reanimated/lib/typescript/reanimated2/animation/decay" but cannot be named